### PR TITLE
feat: add json output

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -73,6 +73,22 @@ async function runMain(assetBenchProducer, workers, options) {
       console.log(`${round(txCount / blockCount)} tx/block`);
       console.log(`${round(duration / blockCount)} sec/block`);
       console.log(`${round(txCount / duration)} tx/sec`);
+
+      if (options.json) {
+        var a = {
+          'blocks': [],
+          'tx_block': round(txCount / blockCount),
+          'sec_block': round(duration / blockCount),
+          'tx_sec': round(txCount / duration),
+        };
+        Object.entries(blocks)
+          .sort((l, r) => Number(l[0]) - Number(r[0]))
+          .forEach(([id, info]) => {
+            a.blocks.push([parseInt(id), info.transactionsCount, info.round])
+          });
+        console.log(JSON.stringify(a))
+        return;
+      }
     });
 
     function finishedBench(err) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const { args } = program
   .option("--receiver [receiver]", "receiver of the transfer", "0x103e9b982b443592ffc3d4c2a484c220fb3e29e2e4")
   .option("--verbose", "show verbose info, use it for debug", false)
   .option("--cpu [cpu]", "cpu nums", 3)
+  .option("--json", "print output as json", false)
   .name("muta-bench")
   .usage(
     "-m POST -d 60 -c 20 --gap 30 --receiver 0x1000000000000000000000000000000000000000 --pk 0x45c56be699dca666191ad3446897e0f480da234da896270202514a0e1a587c3f http://127.0.0.1:8000/graphql"


### PR DESCRIPTION
When `--json` flag appended, a formatted json string will output. Aim to give a simple way to parse the output.

```sh
./muta-bench ... --json ...
```

```
... 
{"blocks":[[1061,0,0],[1062,1666,0],[1063,2758,0],[1064,1949,0],[1065,2097,0],[1066,2584,0],[1067,2664,0],[1068,2621,0],[1069,2579,0],[1070,2708,0],[1071,2715,0],[1072,2780,0],[1073,2794,0],[1074,2830,0],[1075,2787,0],[1076,2791,0],[1077,2775,0],[1078,2763,0],[1079,2844,0],[1080,2600,0],[1081,0,0],[1082,0,0]],"tx_block":"2465.25","sec_block":"3.01","tx_sec":"819.02"}
```